### PR TITLE
Runtime configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,11 +21,15 @@ RUN chmod +x /tmp/ejabberd-installer.run
 RUN /tmp/ejabberd-installer.run --mode unattended --prefix /opt/ejabberd --adminpw ejabberd
 
 # config
-ADD ./ejabberd.yml /opt/ejabberd/conf/ejabberd.yml
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install python-jinja2
+ADD ./ejabberd.yml.tpl /opt/ejabberd/conf/ejabberd.yml.tpl
 ADD ./ejabberdctl.cfg /opt/ejabberd/conf/ejabberdctl.cfg
-
 RUN sed -i "s/ejabberd.cfg/ejabberd.yml/" /opt/ejabberd/bin/ejabberdctl
+
+# wrapper for setting config on disk from environment
+# allows setting things like XMPP domain at runtime
+ADD ./run /opt/ejabberd/bin/run
 
 EXPOSE 5222 5269 5280
 CMD ["live"]
-ENTRYPOINT ["/opt/ejabberd/bin/ejabberdctl"]
+ENTRYPOINT ["/opt/ejabberd/bin/run"]

--- a/README.md
+++ b/README.md
@@ -40,3 +40,19 @@ xmpp:
 * 5222
 * 5269
 * 5280
+
+## Runtime configuration
+
+By default the container will serve the XMPP domain `localhost`. In order to serve a different domain at runtime, provide the `XMPP_DOMAIN` variable as such:
+
+```
+$ docker run -t -i -p 5222 -p 5269 -p 5280 -e "XMPP_DOMAIN=foo.com" rroemhild/ejabberd
+```
+
+You can additionally provide extra runtime configuration in a downstream image by replacing the config template with one based on this image's template
+
+```
+ADD ./ejabberd.yml.tpl /opt/ejabberd/conf/ejabberd.yml.tpl
+```
+
+and include extra interpolation of environment variables. The template is parsed by Jinja2 with the runtime environment (equivalent to Python's `os.environ` available as `env`).

--- a/ejabberd.yml.tpl
+++ b/ejabberd.yml.tpl
@@ -59,7 +59,7 @@ loglevel: 4
 ##   - "example.org"
 ##
 hosts:
-  - "localhost"
+  - "{{ env['XMPP_DOMAIN'] or "localhost" }}"
 
 ##
 ## route_subdomains: Delegate subdomains to other XMPP servers.

--- a/run
+++ b/run
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cat /opt/ejabberd/conf/ejabberd.yml.tpl | python -c "import sys; import os; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))" > /opt/ejabberd/conf/ejabberd.yml
+exec /opt/ejabberd/bin/ejabberdctl "$@"


### PR DESCRIPTION
Allows run-time configuration by inserting environment variable interpolation in the template config file.

Based on #3, that should be merged first.
