### PR TITLE
automatically updates the module specs

### DIFF
--- a/scripts/post/10_ejabberd_modules_update_specs.sh
+++ b/scripts/post/10_ejabberd_modules_update_specs.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+# Updates the known modules as to be found in https://github.com/processone/ejabberd-contrib
+
+source "${EJABBERD_ROOT}/bin/scripts/lib/config.sh"
+source "${EJABBERD_ROOT}/bin/scripts/lib/functions.sh"
+
+run_modules_update_specs() {
+    echo 'Updating module specs...'
+    ${EJABBERDCTL} modules_update_specs
+}
+
+is_set ${EJABBERDCTL} \
+    && run_modules_update_specs
+
+exit 0


### PR DESCRIPTION
https://github.com/processone/ejabberd-contrib is a source for common plugins.

What this repo fails to mention in its readme, is that you first need to call:

    ejabberdctl modules_update_specs

before calling

    ejabberdctl module_install <module>

Otherwise, no modules will be available!

This pull request automates this first step.