### PR TITLE
Allow certificates to be given via env variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,17 @@ You can terminate the erlang shell with `q().`.
 
 TLS is enabled by default and the run script will auto-generate two snakeoil certificates during boot if you don't provide your ssl certificates.
 
-To use your own certificates mount the volume `/opt/ejabberd/ssl` to a local directory with the `.pem` files:
+To use your own certificates, there are two options.
+
+1. Mount the volume `/opt/ejabberd/ssl` to a local directory with the `.pem` files:
 
 * /tmp/ssl/host.pem (SERVER_HOSTNAME)
 * /tmp/ssl/xmpp_domain.pem (XMPP_DOMAIN)
 
 Make sure that the certificate and private key are in one `.pem` file. If one file is missing it will be auto-generated. I.e. you can provide your certificate for your `XMMP_DOMAIN` and use a snakeoil certificate for the `SERVER_HOSTNAME`.
+
+2. Specify the certificates via environment variables: `SSLCERT_HOST` and `SSLCERT_EXAMPLE_COM`. For the
+domain certificates, make sure you match the domain names given in `XMPP_DOMAIN`.
 
 ## Using docker-ejabberd as base image
 

--- a/scripts/pre/00_write_certifiates_from_env.sh
+++ b/scripts/pre/00_write_certifiates_from_env.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e
+
+source "${EJABBERD_HOME}/scripts/lib/base_config.sh"
+source "${EJABBERD_HOME}/scripts/lib/config.sh"
+source "${EJABBERD_HOME}/scripts/lib/base_functions.sh"
+source "${EJABBERD_HOME}/scripts/lib/functions.sh"
+
+# Instead of having to mount a direction, specify the ssl certs
+# via environment variables:
+# `SSLCERT_HOST` and `SSLCERT_{domain_name}`.
+# For example: `SSLCERT_EXAMPLE_COM`.
+
+write_file_from_env() {
+    echo "Writing $1 to $2"
+    mkdir -p "$(dirname $2)"
+    echo "${!1}" > $2
+}
+
+# Write the host certificate
+is_set ${SSLCERT_HOST} \
+  && write_file_from_env "SSLCERT_HOST" ${SSLCERTHOST}
+
+# Write the domain certificates for each XMPP_DOMAIN
+for xmpp_domain in ${XMPP_DOMAIN} ; do
+    var="SSLCERT_$(echo $xmpp_domain | awk '{print toupper($0)}' | sed 's/\./_/g')"
+    if is_set ${!var} ; then
+        file_exist "${SSLCERTDIR}/${xmpp_domain}.pem" \
+          || write_file_from_env "$var" "${SSLCERTDIR}/${xmpp_domain}.pem"
+    fi
+done
+
+exit 0


### PR DESCRIPTION
Using a volume is kind of a pain, since it's not very portable; even discouraged by the Docker team AFAIK.

This allows you to specify the certificates via environment variables, as an option.