### PR TITLE
Removed adding source repository for erlang

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,11 +45,9 @@ RUN set -x \
         libyaml-0-2 \
         erlang-base erlang-snmp erlang-ssl erlang-ssh erlang-webtool \
         erlang-tools erlang-xmerl erlang-corba erlang-diameter erlang-eldap \
-        erlang-eunit erlang-ic erlang-inviso erlang-odbc erlang-os-mon \
+        erlang-eunit erlang-ic erlang-odbc erlang-os-mon \
         erlang-parsetools erlang-percept erlang-typer \
 	' \
-	&& echo 'deb http://packages.erlang-solutions.com/debian jessie contrib' >> \
-        /etc/apt/sources.list \
     && apt-key adv \
         --keyserver keys.gnupg.net \
         --recv-keys 434975BD900CCBE4F7EE1B1ED208507CA14F4FCA \


### PR DESCRIPTION
On Debian Jessie, the Erlang version that is installed by default is 17.3, which is compatible with Ejabberd. If however you add the 'http://packages.erlang-solutions.com/debian' source repo, Erlang 18.x will be installed, which is INCOMPATIBLE with Ejabberd.

After I've removed the source repo, I also had to remove erlang-inviso, since that package was no longer available.