### PR TITLE
Auth method ldap

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ EJABBERD_USERS=admin@example.ninja:password1234
 Or without a random password printed to stdout (check container logs):
 
 ```
-EJABBERD_USERS=admin@example.ninja
+EJABBERD_USER=admin@example.ninja
 ```
 
 Register more than one user:

--- a/README.md
+++ b/README.md
@@ -152,6 +152,30 @@ Internal and anonymous authentication:
 AUTH_METHOD=internal anonymous
 ```
 
+### LDAP Auth
+
+Full documentation http://docs.ejabberd.im/admin/guide/configuration/#ldap.
+
+Connection
+
+- **EJABBERD_LDAP_SERVERS**: List of IP addresses or DNS names of your LDAP servers. This option is required.
+- **EJABBERD_LDAP_ENCRYPT**: The value `tls` enables encryption by using LDAP over SSL. The default value is: `none`.
+- **EJABBERD_LDAP_TLS_VERIFY**: `false|soft|hard` This option specifies whether to verify LDAP server certificate or not when TLS is enabled. The default is `false` which means no checks are performed.
+- **EJABBERD_LDAP_TLS_CACERTFILE**: Path to file containing PEM encoded CA certificates.
+- **EJABBERD_LDAP_TLS_DEPTH**: Specifies the maximum verification depth when TLS verification is enabled. The default value is 1.
+- **EJABBERD_LDAP_PORT**: The default port is `389` if encryption is disabled; and `636` if encryption is enabled.
+- **EJABBERD_LDAP_ROOTDN**: Bind DN. The default value is "" which means ‘anonymous connection’.
+- **EJABBERD_LDAP_PASSWORD**: Bind password. The default value is "".
+- **EJABBERD_LDAP_DEREF_ALIASES**: `never|always|finding|searching`
+   Whether or not to dereference aliases. The default is `never`.
+
+Authentication
+
+- **EJABBERD_LDAP_BASE**: LDAP base directory which stores users accounts. This option is required.
+u- **EJABBERD_LDAP_UIDS**: `ldap_uidattr:ldap_uidattr_format` The default attributes are `uid:%u`.
+- **EJABBERD_LDAP_FILTER**: RFC 4515 LDAP filter. The default Filter value is undefined.
+- **EJABBERD_LDAP_DN_FILTER**: `{ Filter: FilterAttrs }` This filter is applied on the results returned by the main filter. By default ldap_dn_filter is undefined.
+
 ## Admins
 
 Set one or more admin user (seperated by whitespace) with the **EJABBERD_ADMINS** environment variable. You can register admin users with the **EJABBERD_USERS** environment variable during container startup, use you favorite XMPP client or the `ejabberdctl` command line utility.
@@ -173,7 +197,7 @@ EJABBERD_USERS=admin@example.ninja:password1234
 Or without a random password printed to stdout (check container logs):
 
 ```
-EJABBERD_USER=admin@example.ninja
+EJABBERD_USERS=admin@example.ninja
 ```
 
 Register more than one user:
@@ -186,9 +210,8 @@ EJABBERD_USERS=admin@example.ninja:password1234 user1@test.com user1@xyz.io
 
 - **EJABBERD_SSLCERT_HOST**: SSL Certificate for the hostname.
 - **EJABBERD_SSLCERT_EXAMPLE_COM**: SSL Certificates for XMPP domains.
-- **EJABBERD_STARTTLS**: Set to false to disable StartTLS for client to server connections. Defaults
- to `true`.
-- **EJABBERD_S2S_SSL**: Set to false to disable SSL in server 2 server connections. Defaults to `true`.
+- **EJABBERD_STARTTLS**: Set to `false` to disable StartTLS for client to server connections. Defaults to `true`.
+- **EJABBERD_S2S_SSL**: Set to `false` to disable SSL in server 2 server connections. Defaults to `true`.
 - **EJABBERD_WEB_ADMIN_SSL**: If your proxy terminates SSL you may want to disable HTTPS. Defaults to `true`.
 
 ## Erlang

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Connection
 Authentication
 
 - **EJABBERD_LDAP_BASE**: LDAP base directory which stores users accounts. This option is required.
-u- **EJABBERD_LDAP_UIDS**: `ldap_uidattr:ldap_uidattr_format` The default attributes are `uid:%u`.
+- **EJABBERD_LDAP_UIDS**: `ldap_uidattr:ldap_uidattr_format` The default attributes are `uid:%u`.
 - **EJABBERD_LDAP_FILTER**: RFC 4515 LDAP filter. The default Filter value is undefined.
 - **EJABBERD_LDAP_DN_FILTER**: `{ Filter: FilterAttrs }` This filter is applied on the results returned by the main filter. By default ldap_dn_filter is undefined.
 

--- a/conf/ejabberd.yml.tpl
+++ b/conf/ejabberd.yml.tpl
@@ -98,7 +98,61 @@ auth_method:
 {%- if 'anonymous' in env.get('EJABBERD_AUTH_METHOD', 'internal').split() %}
 anonymous_protocol: login_anon
 allow_multiple_connections: true
-{% endif %}
+{%- endif %}
+
+
+## LDAP authentication
+
+{%- if 'ldap' in env.get('AUTH_METHOD', 'internal').split() %}
+
+ldap_servers:
+{%- for ldap_server in env.get('EJABBERD_LDAP_SERVERS', 'internal').split() %}
+  - "{{ ldap_server }}"
+{%- endfor %}
+
+ldap_encrypt: {{ env.get('EJABBERD_LDAP_ENCRYPT', 'none') }}
+ldap_tls_verify: {{ env.get('EJABBERD_LDAP_TLS_VERIFY', 'false') }}
+
+{%- if env['EJABBERD_LDAP_TLS_CACERTFILE'] %}
+ldap_tls_cacertfile: "{{ env['EJABBERD_LDAP_TLS_CACERTFILE'] }}"
+{%- endif %}
+
+ldap_tls_depth: {{ env.get('EJABBERD_LDAP_TLS_DEPTH', 1) }}
+
+{%- if env['EJABBERD_LDAP_PORT'] %}
+ldap_port: {{ env['EJABBERD_LDAP_PORT'] }}
+{%- endif %}
+
+{%- if env['EJABBERD_LDAP_ROOTDN'] %}
+ldap_rootdn: "{{ env['EJABBERD_LDAP_ROOTDN'] }}"
+{%- endif %}
+
+{%- if env['EJABBERD_LDAP_PASSWORD'] %}
+ldap_password: "{{ env['EJABBERD_LDAP_PASSWORD'] }}"
+{%- endif %}
+
+ldap_deref_aliases: {{ env.get('EJABBERD_LDAP_DEREF_ALIASES', 'never') }}
+ldap_base: "{{ env['EJABBERD_LDAP_BASE'] }}"
+
+{%- if env['EJABBERD_LDAP_UIDS'] %}
+ldap_uids:
+{%- for ldap_uid in env['EJABBERD_LDAP_UIDS'].split() %}
+  "{{ ldap_uid.split(':')[0] }}": "{{ ldap_uid.split(':')[1] }}"
+{%- endfor %}
+{%- endif %}
+
+{%- if env['EJABBERD_LDAP_FILTER'] %}
+ldap_filter: {{ env['EJABBERD_LDAP_FILTER'] }}
+{%- endif %}
+
+{%- if env['EJABBERD_LDAP_DN_FILTER'] %}
+ldap_dn_filter:
+{%- for dn_filter in env['EJABBERD_LDAP_DN_FILTER'].split() %}
+  "{{ dn_filter.split(':')[0] }}": ["{{ dn_filter.split(':')[1] }}"]
+{%- endfor %}
+{%- endif %}
+
+{%- endif %}
 
 ###   ===============
 ###   TRAFFIC SHAPERS

--- a/scripts/lib/base_config.sh
+++ b/scripts/lib/base_config.sh
@@ -46,5 +46,4 @@ set +e
 [[ -n $LOGLEVEL ]] \
     && export EJABBERD_LOGLEVEL=${LOGLEVEL}
 
-
 set -e


### PR DESCRIPTION
Add LDAP authentication support as requested in #67. So far I've only tested this with the following docker-compose file:

```
ldap:
    image: rroemhild/test-openldap

ejabberd:
    build: .
    ports:
        - 5222:5222
        - 5280:5280
    links:
        - ldap
    environment:
        - "XMPP_DOMAIN=planetexpress.com"
        - "EJABBERD_ADMIN=professor@planetexpress.com"
        - "SKIP_MODULES_UPDATE=true"
        - "AUTH_METHOD=ldap"
        - "EJABBERD_LDAP_SERVERS=ldap"
        - "EJABBERD_LDAP_BASE=dc=planetexpress,dc=com"
```

@flecno can you test this with your setup please?

Should we also support `mod_vcard_ldap` and `mod_shared_roster_ldap` with this container image?