### PR TITLE
Preventing modules from being re-installed on subsequent starts

### DIFF
--- a/scripts/post/11_ejabberd_install_modules.sh
+++ b/scripts/post/11_ejabberd_install_modules.sh
@@ -54,6 +54,9 @@ install_module() {
     return 0;
 }
 
+file_exist ${FIRST_START_DONE_FILE} \
+    && exit 0
+
 if [ -n "${EJABBERD_SOURCE_MODULES}" ]; then
     for module_name in ${EJABBERD_SOURCE_MODULES} ; do
         install_module ${module_name}


### PR DESCRIPTION
Currently, the module installer is only meant to run as a part of the first run, not upon subsequent starts. I've added a check for the `FIRST_START_DONE_FILE` file in order to fix this.