### PR TITLE
Adding support for installing ejabberd_contrib modules and custom auth modules

### DIFF
--- a/scripts/post/11_ejabberd_install_modules.sh
+++ b/scripts/post/11_ejabberd_install_modules.sh
@@ -133,6 +133,9 @@ if [ ${is_restart_needed} -eq 1 ]; then
     if is_true ${EJABBERD_RESTART_AFTER_MODULE_INSTALL} ; then
         echo "Restarting ejabberd after successful module installation(s)"
         ${EJABBERDCTL} restart
+        child=$!
+        ${EJABBERDCTL} "started"
+        wait $child
     fi
 fi
 

--- a/scripts/post/11_ejabberd_install_modules.sh
+++ b/scripts/post/11_ejabberd_install_modules.sh
@@ -8,7 +8,7 @@ source "${EJABBERD_HOME}/scripts/lib/config.sh"
 source "${EJABBERD_HOME}/scripts/lib/base_functions.sh"
 source "${EJABBERD_HOME}/scripts/lib/functions.sh"
 
-install_module() {
+install_module_from_source() {
     local module_name=$1
     local module_source_path=${EJABBERD_HOME}/module_source/${module_name}
     local module_install_folder=${EJABBERD_HOME}/.ejabberd-modules/sources/${module_name}
@@ -54,14 +54,50 @@ install_module() {
     return 0;
 }
 
+install_module_from_ejabberd_contrib() {
+    local module_name=$1
+
+    # Check to see if the module is already installed
+    local install_count=$(${EJABBERDCTL} modules_installed | grep -ce "^${module_name}[[:space:]]")
+    if [ $install_count -gt 0 ]; then
+        echo "Error: Module already installed: ejabberd_contrib ${module_name}"
+        return 1;
+    fi
+
+    # Install the module
+    echo "Running module_install on ejabberd_contrib ${module_name}"
+    ${EJABBERDCTL} module_install ${module_name}
+    if [ $? -ne 0 ]; then
+        echo "Module installation failed for ejabberd_contrib ${module_name}"
+        return 1;
+    fi
+    echo "Module installation succeeded for ejabberd_contrib ${module_name}"
+
+    return 0;
+}
+
 file_exist ${FIRST_START_DONE_FILE} \
     && exit 0
 
+did_modules_install=0;
+
 if [ -n "${EJABBERD_SOURCE_MODULES}" ]; then
     for module_name in ${EJABBERD_SOURCE_MODULES} ; do
-        install_module ${module_name}
+        install_module_from_source ${module_name}
     done
+    did_modules_install=1;
+fi
 
+# Check the EJABBERD_CONTRIB_MODULES variable for any ejabberd_contrib modules
+if [ -n "${EJABBERD_CONTRIB_MODULES}" ]; then
+    for module_name in ${EJABBERD_CONTRIB_MODULES} ; do
+        install_module_from_ejabberd_contrib ${module_name}
+    done
+    did_modules_install=1;
+fi
+
+# If any modules were installed, restart the server, if the option is enabled
+if [ ${did_modules_install} -eq 1 ]; then
     if is_true ${EJABBERD_RESTART_AFTER_MODULE_INSTALL} ; then
         echo "Restarting ejabberd after successful module installation(s)"
         ${EJABBERDCTL} restart


### PR DESCRIPTION
I've added a handler for a new environment variable, `EJABBERD_CONTRIB_MODULES`.  The handling script will iterate over values in that variable and call `ejabberdctl module_install` on it. 

Here's a working example using my forked image on Docker hub:

```
docker run --rm=true \
    -h 'localhost' \
    -e "ERLANG_NODE=ejabberd" \
    -e "EJABBERD_CONTRIB_MODULES=mod_rest mod_archive" \
    -e "EJABBERD_RESTART_AFTER_MODULE_INSTALL=true" \
    andrewdb/ejabberd
```

The above would create a new instance of docker-ejabberd with the [ejabberd_contrib](https://github.com/processone/ejabberd-contrib) modules [mod_rest](https://github.com/processone/ejabberd-contrib/tree/master/mod_rest) and [mod_archive](https://github.com/processone/ejabberd-contrib/tree/master/mod_archive) pre-installed.

Also, I've added another new environment variable, `EJABBERD_CUSTOM_AUTH_MODULE_OVERRIDE`. This allows you to provide the name of a custom module which can handle auth.