### PR TITLE
Add option to hide ejabberd version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ EJABBERD_USERS=admin@example.ninja:password1234 user1@test.com user1@xyz.io
 - **EJABBERD_MOD_MUC_ADMIN**: Activate the mod_muc_admin module. Defaults to `false`.
 - **EJABBERD_MOD_ADMIN_EXTRA**: Activate the mod_muc_admin module. Defaults to `true`.
 - **EJABBERD_REGISTER_TRUSTED_NETWORK_ONLY**: Only allow user registration from the trusted_network access rule. Defaults to `true`.
+- **EJABBERD_MOD_VERSION**: Activate the mod_version module. Defaults to `true`.
 
 ## Logging
 

--- a/conf/ejabberd.yml.tpl
+++ b/conf/ejabberd.yml.tpl
@@ -379,7 +379,9 @@ modules:
   mod_stats: {}
   mod_time: {}
   mod_vcard: {}
+  {% if env.get('EJABBERD_MOD_VERSION', true) == "true" %}
   mod_version: {}
+  {% endif %}
   mod_http_upload:
     docroot: "/opt/ejabberd/upload"
     {%- if env['EJABBERD_HTTPS'] == "true" %}


### PR DESCRIPTION
For security reasons, there should be a possibility to hide the
version number. The new env variable `EJABBERD_MOD_VERSION` defaults
to `true`, i.e. the module is enabled.