### PR TITLE
Updated variable names

### DIFF
--- a/conf/ejabberd.yml.tpl
+++ b/conf/ejabberd.yml.tpl
@@ -311,6 +311,9 @@ modules:
   ##   docroot: "/var/www"
   ##   accesslog: "/var/log/ejabberd/access.log"
   mod_last: {}
+  mod_mam:
+    db_type: odbc
+    default: always
   mod_muc:
     host: "conference.@HOST@"
     access: muc
@@ -409,6 +412,8 @@ sql_server: "{{ env['EJABBERD_ODBC_SERVER'] }}"
 sql_database: "{{ env['EJABBERD_ODBC_DATABASE'] }}"
 sql_username: "{{ env['EJABBERD_ODBC_USERNAME'] }}"
 sql_password: "{{ env['EJABBERD_ODBC_PASSWORD'] }}"
+
+default_db: sql
 {% endif %}
 
 {%- if env['EJABBERD_DEFAULT_DB'] is defined %}

--- a/conf/ejabberd.yml.tpl
+++ b/conf/ejabberd.yml.tpl
@@ -404,12 +404,11 @@ host_config:
 {%- if env['EJABBERD_CONFIGURE_ODBC'] == "true" %}
 ###   ====================
 ###   ODBC DATABASE CONFIG
-odbc_type: {{ env['EJABBERD_ODBC_TYPE'] }}
-odbc_server: {{ env['EJABBERD_ODBC_SERVER'] }}
-odbc_database: {{ env['EJABBERD_ODBC_DATABASE'] }}
-odbc_username: {{ env['EJABBERD_ODBC_USERNAME'] }}
-odbc_password: {{ env['EJABBERD_ODBC_PASSWORD'] }}
-odbc_pool_size: {{ env['EJABBERD_ODBC_POOL_SIZE'] }}
+sql_type: {{ env['EJABBERD_ODBC_TYPE'] }}
+sql_server: "{{ env['EJABBERD_ODBC_SERVER'] }}"
+sql_database: "{{ env['EJABBERD_ODBC_DATABASE'] }}"
+sql_username: "{{ env['EJABBERD_ODBC_USERNAME'] }}"
+sql_password: "{{ env['EJABBERD_ODBC_PASSWORD'] }}"
 {% endif %}
 
 {%- if env['EJABBERD_DEFAULT_DB'] is defined %}


### PR DESCRIPTION
The variables beginning with "odbc" are deprecated and don't work when using a SQL backend.
