### PR TITLE
Copy module to .ejabberd-modules/sources instead of too deep directory.

### DIFF
--- a/scripts/post/11_ejabberd_install_modules.sh
+++ b/scripts/post/11_ejabberd_install_modules.sh
@@ -11,7 +11,7 @@ source "${EJABBERD_HOME}/scripts/lib/functions.sh"
 install_module_from_source() {
     local module_name=$1
     local module_source_path=${EJABBERD_HOME}/module_source/${module_name}
-    local module_install_folder=${EJABBERD_HOME}/.ejabberd-modules/sources/${module_name}
+    local module_install_folder=${EJABBERD_HOME}/.ejabberd-modules/sources
     
     echo "Analyzing module ${module_name} for installation"
     # Make sure that the module exists in the source folder before attempting a copy


### PR DESCRIPTION
A module named `my_module` would be copied to `$EJABBERD_HOME/.ejabberd-modules/sources/my_module/my_module`.