### PR TITLE
Revert "Skip generating SSL certificates user provides config yml"

### DIFF
--- a/scripts/pre/02_make_snakeoil_certificates.sh
+++ b/scripts/pre/02_make_snakeoil_certificates.sh
@@ -61,11 +61,6 @@ make_domain_snakeoil_certificate() {
 }
 
 
-if [ -e ${CONFIGFILE} ]; then
-    echo "Skipping certificate generation because ${CONFIGFILE} exists..."
-    exit 0
-fi
-
 ## backward compatibility
 # link old xmpp_domain.pem file to the first <domainname>.pem in XMPP_DOMAIN
 readonly SSLCERTDOMAIN="${SSLCERTDIR}/xmpp_domain.pem"

--- a/scripts/pre/03_make_dhparam.sh
+++ b/scripts/pre/03_make_dhparam.sh
@@ -14,11 +14,6 @@ make_dhparam() {
 	openssl dhparam -out ${dhfile} ${bits}
 }
 
-if [ -e ${CONFIGFILE} ]; then
-    echo "Skipping dh param generation because ${CONFIGFILE} exists..."
-    exit 0
-fi
-
 if is_true ${EJABBERD_DHPARAM} ; then
 	file_exist ${SSLDHPARAM} \
 		|| make_dhparam ${SSLDHPARAM} 4096


### PR DESCRIPTION
pre/02_make_snakeoil_certificates.sh already skip the generation off SSL certificates if they exist.