### PR TITLE
Create /var/log/ejabberd directory or change LOG_DIR to /usr/local/var/log/ejabberd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,6 +89,10 @@ RUN set -x \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get purge -y --auto-remove $buildDeps
 
+# Create logging directories
+RUN mkdir -p /var/log/ejabberd
+RUN touch /var/log/ejabberd/crash.log /var/log/ejabberd/error.log /var/log/ejabberd/erlang.log
+
 # Wrapper for setting config on disk from environment
 # allows setting things like XMPP domain at runtime
 ADD ./run.sh /sbin/run

--- a/scripts/lib/base_config.sh
+++ b/scripts/lib/base_config.sh
@@ -11,7 +11,7 @@ readonly CTLCONFIGTEMPLATE="${EJABBERD_HOME}/conf/ejabberdctl.cfg.tpl"
 readonly SSLCERTDIR="${EJABBERD_HOME}/ssl"
 readonly SSLCERTHOST="${SSLCERTDIR}/host.pem"
 readonly SSLDHPARAM="${SSLCERTDIR}/dh.pem"
-readonly LOGDIR="/var/log/ejabberd"
+readonly LOGDIR="/usr/local/var/log/ejabberd"
 readonly FIRST_START_DONE_FILE="/${EJABBERD_HOME}/first-start-done"
 readonly CLUSTER_NODE_FILE="/${EJABBERD_HOME}/cluster-done"
 


### PR DESCRIPTION
I noticed that three files are being tailed after startup of the ejabberd server: /var/log/ejabberd/crash.log, /var/log/ejabberd/error.log, and /var/log/ejabberd/erlang.log. The tail command fails, however, because those files, including the path /var/log/ejabberd, do not exist.

Despite the files not existing under /var/log/ejabberd they do exist under /usr/local/var/log/ejabberd/, which was added during installation of ejabberd, so one of two changes should be made:

1. Change the LOG_DIR variable in the base_config.sh script to "/usr/local/var/log/ejabberd" instead of "/var/log/ejabberd".

2. Create the directory /var/log/ejabberd and the files crash.log, error.log, and erlang.log in this directory during image creation, i.e. add two steps in the dockerfile.

I have made both of the above mentioned changes, so you can choose either of them to merge to your master if you find them correct.

Alternatively you could add the --localstatedir flag to the ./configure step before compiling ejabberd. This is probably the solution I would prefer.