### PR TITLE
Feature/140 specify custom cert paths per domain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,15 +96,6 @@ RUN wget -P /usr/local/share/ca-certificates/cacert.org http://www.cacert.org/ce
 
 ENV GOSU_VERSION 1.10
 RUN set -ex; \
-    \
-    fetchDeps=' \
-        ca-certificates \
-        wget \
-    '; \
-    apt-get update; \
-    apt-get install -y --no-install-recommends $fetchDeps; \
-    rm -rf /var/lib/apt/lists/*; \
-    \
     dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
     wget -O /usr/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
     wget -O /usr/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,6 +94,31 @@ RUN set -x \
 RUN wget -P /usr/local/share/ca-certificates/cacert.org http://www.cacert.org/certs/root.crt http://www.cacert.org/certs/class3.crt; \
     update-ca-certificates
 
+ENV GOSU_VERSION 1.10
+RUN set -ex; \
+    \
+    fetchDeps=' \
+        ca-certificates \
+        wget \
+    '; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends $fetchDeps; \
+    rm -rf /var/lib/apt/lists/*; \
+    \
+    dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+    wget -O /usr/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+    wget -O /usr/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+    \
+# verify the signature
+    export GNUPGHOME="$(mktemp -d)"; \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+    gpg --batch --verify /usr/bin/gosu.asc /usr/bin/gosu; \
+    rm -r "$GNUPGHOME" /usr/bin/gosu.asc; \
+    \
+    chmod +sx /usr/bin/gosu; \
+# verify that the binary works
+    gosu nobody true;
+
 # Create logging directories
 RUN mkdir -p /var/log/ejabberd
 RUN touch /var/log/ejabberd/crash.log /var/log/ejabberd/error.log /var/log/ejabberd/erlang.log

--- a/scripts/pre/01a_copy_ssl_certs_and_watch.sh
+++ b/scripts/pre/01a_copy_ssl_certs_and_watch.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+source "${EJABBERD_HOME}/scripts/lib/base_config.sh"
+source "${EJABBERD_HOME}/scripts/lib/config.sh"
+source "${EJABBERD_HOME}/scripts/lib/base_functions.sh"
+source "${EJABBERD_HOME}/scripts/lib/functions.sh"
+
+write_file_from_files() {
+    echo "Writing $1 to $2"
+    mkdir -p "$(dirname $2)"
+    gosu root cat ${!1} > $2
+}
+
+# Write the host certificate
+is_set ${EJABBERD_SSLCERT_HOST_PATH} \
+  && write_file_from_files "EJABBERD_SSLCERT_HOST_PATH" ${SSLCERTHOST}
+
+# Write the domain certificates for each XMPP_DOMAIN
+for xmpp_domain in ${XMPP_DOMAIN} ; do
+    var="EJABBERD_SSLCERT_$(echo $xmpp_domain | awk '{print toupper($0)}' | sed 's/\./_/g;s/-/_/g')_PATH"
+    if is_set ${!var} ; then
+        write_file_from_files "$var" "${SSLCERTDIR}/${xmpp_domain}.pem"
+    fi
+done
+
+exit 0


### PR DESCRIPTION
fixes #140 

Allow setting certificate-paths via environment-variables. Allow the source-certs to be only readable by root. Allow joining multiple certificate-files together.