### PR TITLE
update to 17.08

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:jessie
 MAINTAINER Rafael Römhild <rafael@roemhild.de>
 
-ENV EJABBERD_BRANCH=17.04 \
+ENV EJABBERD_BRANCH=17.08 \
     EJABBERD_USER=ejabberd \
     EJABBERD_HTTPS=true \
     EJABBERD_STARTTLS=true \
@@ -52,6 +52,7 @@ RUN set -x \
         python-mysqldb \
         imagemagick \
     ' \
+    && echo "deb http://packages.erlang-solutions.com/debian wheezy contrib" >> /etc/apt/sources.list \
     && apt-key adv \
         --keyserver keys.gnupg.net \
         --recv-keys 434975BD900CCBE4F7EE1B1ED208507CA14F4FCA \

--- a/conf/ejabberd.yml.tpl
+++ b/conf/ejabberd.yml.tpl
@@ -349,6 +349,8 @@ modules:
       - "flat"
       - "hometree"
       - "pep" # pep requires mod_caps
+  mod_push: {}
+  mod_push_keepalive: {}
   mod_register:
     ##
     ## Protect In-Band account registrations with CAPTCHA.


### PR DESCRIPTION
update to 17.08 and damn, i forgot i pulled in the cacert pr from MaZderMind.
I needed to add the official erlang repository because the debian ones are too old to build 17.08.