### PR TITLE
Create log files if they don't exist

### DIFF
--- a/scripts/pre/50_create_logfiles.sh
+++ b/scripts/pre/50_create_logfiles.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+source "${EJABBERD_HOME}/scripts/lib/base_config.sh"                            
+source "${EJABBERD_HOME}/scripts/lib/config.sh" 
+
+for LOG in crash.log error.log erlang.log ; do
+
+    if ! [ -f ${LOGDIR}/${LOG} ] ; then
+        echo  "Creating ${LOGDIR}/${LOG}"
+        touch ${LOGDIR}/${LOG}
+    fi
+done


### PR DESCRIPTION
When starting the image for the first time you get:

```
tail: cannot open ‘/usr/local/var/log/ejabberd/crash.log’ for reading:
No such file or directory
tail: cannot open ‘/usr/local/var/log/ejabberd/error.log’ for reading:
No such file or directory
tail: cannot open ‘/usr/local/var/log/ejabberd/erlang.log’ for reading:
No such file or directory
```

This script will touch the files *IF* they don't exist during "pre"