### PR TITLE
Package ghostscript is required by CAPTCHA

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,7 @@ RUN set -x \
         erlang-tools erlang-xmerl erlang-corba erlang-diameter erlang-eldap \
         erlang-eunit erlang-ic erlang-odbc erlang-os-mon \
         erlang-parsetools erlang-percept erlang-typer \
+        ghostscript \
         imagemagick \
         inotify-tools \
         libgd3 \


### PR DESCRIPTION
Fixes
```
convert-im6.q16: unable to read font `(null)' @ error/annotate.c/RenderFreetype/1362.
```