### PR TITLE
Updated the Current version to 18.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Dockerfile to build an [ejabberd][] container image.
 
 ## Version
 
-Current Version: `18.03`
+Current Version: `18.04`
 
 Docker Tag Names are based on ejabberd versions in git [branches][] and [tags][]. The image tag `:latest` is based on the master branch.
 


### PR DESCRIPTION
The current version of ejabberd in the Dockerfile seems to be `18.04` so updating that in the Readme.
 https://github.com/rroemhild/docker-ejabberd/blob/master/Dockerfile#L7