### PR TITLE
Replace ghostscript with gsfonts. Add `captcha_cmd` parameter.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN set -x \
         erlang-tools erlang-xmerl erlang-corba erlang-diameter erlang-eldap \
         erlang-eunit erlang-ic erlang-odbc erlang-os-mon \
         erlang-parsetools erlang-percept erlang-typer \
-        ghostscript \
+        gsfonts \
         imagemagick \
         inotify-tools \
         libgd3 \

--- a/conf/ejabberd.yml.tpl
+++ b/conf/ejabberd.yml.tpl
@@ -463,3 +463,11 @@ redis_db: {{ env['EJABBERD_REDIS_DB'] or 0}}
 redis_reconnect_timeout: {{ env['EJABBERD_REDIS_RECONNECT_TIMEOUT'] or 1 }}
 redis_connect_timeout: {{ env['EJABBERD_REDIS_CONNECT_TIMEOUT'] or 1 }}
 {% endif %}
+
+###   =======
+###   CAPTCHA
+##
+## Full path to a script that generates the image.
+{%- if env['EJABBERD_CAPTCHA'] == "true" %}
+captcha_cmd: "{{ env.get('EJABBERD_CAPTCHA_CMD', '/usr/local/lib/ejabberd-18.04/priv/bin/captcha.sh') }}"
+{% endif %}


### PR DESCRIPTION
In fact we need the `gsfonts` package to draw CAPTCHA instead of `ghostscript` (it was my mistake).
Also I added `captcha_cmd` parameter to configuration file template. If `EJABBERD_CAPTCHA` environment var value is `true`, `captcha_cmd` will set to `EJABBERD_CAPTCHA_CMD` with fallback to `/usr/local/lib/ejabberd-18.04/priv/bin/captcha.sh`.