### PR TITLE
Set ownership to $EJABBERD_HOME directory

### DIFF
--- a/scripts/pre/00a_set_permissions.sh
+++ b/scripts/pre/00a_set_permissions.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+gosu root chown -R ${EJABBERD_USER}: ${EJABBERD_HOME}
+
+exit 0


### PR DESCRIPTION
We can't mount volumes as user other than `root`. This PR provides sort of workaround without need to run ejabberd container as `root`.