### PR TITLE
Kubernetes working example

### DIFF
--- a/kubernetes/Dockerfile
+++ b/kubernetes/Dockerfile
@@ -22,9 +22,11 @@ USER root
 
 RUN mkdir -p $EJABBERD_HOME/scripts/cluster
 
-COPY ./scripts/cluster/100_ejabberd_join_cluster.sh $EJABBERD_HOME/scripts/100_ejabberd_join_cluster.sh
+COPY ./scripts/cluster/100_ejabberd_join_cluster.sh $EJABBERD_HOME/scripts/cluster/100_ejabberd_join_cluster.sh
 
 COPY ./scripts/lib/base_functions.sh $EJABBERD_HOME/scripts/lib/base_functions.sh
+COPY ./scripts/lib/functions.sh $EJABBERD_HOME/scripts/lib/functions.sh
+
 
 ADD ./run.sh /sbin/run
 
@@ -35,6 +37,7 @@ RUN chown -R $EJABBERD_USER:$EJABBERD_USER $EJABBERD_HOME
 RUN chmod +x /sbin/run
 RUN chmod +x $EJABBERD_HOME/scripts/cluster/100_ejabberd_join_cluster.sh
 RUN chmod +x $EJABBERD_HOME/scripts/lib/base_functions.sh
+RUN chmod +x $EJABBERD_HOME/scripts/lib/functions.sh
 
 USER $EJABBERD_USER
 

--- a/kubernetes/Dockerfile
+++ b/kubernetes/Dockerfile
@@ -1,0 +1,49 @@
+###################################################################
+####That image purpose is to prepare the final image to use with
+###################################################################
+
+#That images as built from the Source directory.
+FROM rroemhild/ejabberd:latest
+
+ENV EJABBERD_USER=ejabberd \
+    EJABBERD_HOME=/opt/ejabberd \
+    EJABBERD_DEFAULT_DB=mnesia \
+    EJABBERD_SKIP_MODULES_UPDATE=true \
+    EJABBERD_LOGLEVEL=4 \
+    EJABBERD_DEBUG_MODE=true \
+    #Set default locale for the environment
+    LC_ALL=C.UTF-8 \
+    LANG=en_US.UTF-8 \
+    LANGUAGE=en_US.UTF-8
+
+USER root
+
+###########################################################################################
+
+RUN mkdir -p $EJABBERD_HOME/scripts/cluster
+
+COPY ./scripts/cluster/100_ejabberd_join_cluster.sh $EJABBERD_HOME/scripts/100_ejabberd_join_cluster.sh
+
+COPY ./scripts/lib/base_functions.sh $EJABBERD_HOME/scripts/lib/base_functions.sh
+
+ADD ./run.sh /sbin/run
+
+##SWITCH BACK TO EJABBERD USER
+
+RUN chown -R $EJABBERD_USER:$EJABBERD_USER $EJABBERD_HOME
+
+RUN chmod +x /sbin/run
+RUN chmod +x $EJABBERD_HOME/scripts/cluster/100_ejabberd_join_cluster.sh
+RUN chmod +x $EJABBERD_HOME/scripts/lib/base_functions.sh
+
+USER $EJABBERD_USER
+
+WORKDIR $EJABBERD_HOME
+
+EXPOSE 4560 5222 5269 5280 5443 4369 4200 4201 4202 4203 4204 4205 4205 4206 4207 4208 4209 4210
+
+VOLUME ["./home:/opt/ejabberd/"]
+
+CMD ["start"]
+
+ENTRYPOINT ["run"]

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,4 +1,4 @@
-## Ejabberd + Kubernetes
+# Ejabberd + Kubernetes
 
 After some googling around, I scratched my head for why there isn't any documented steps to get Ejabberd working with K8s. For that reason after some searchers, I was abled to setup those two together quite easily. Thanks to the awesome rroemhild/ejabberd docker image and all the scripts already created around that image.
 
@@ -6,13 +6,13 @@ Because Kubernetes needs the image pre-built with the scripts and modifications,
 
 I would if approved, suggest rroemhild to later add that to the main branch.
 
-# New environment variable:
+### New environment variable:
 
 ````
 EJABBERD_AUTO_JOIN_CLUSTER: true/false
 ````
 
-# New script
+### New script
 
 I changed the script from the docker-compose-cluster example:
 
@@ -25,13 +25,13 @@ Some other changes:
 
 There is probably a better ways to set them together. And quite frankly, I'm not an expert on either one, but I thought, maybe someone won't waste time researching all over again, and will improve that implementation instead. So stick with me please.
 
-## Step 1 - The environment
+### Step 1 - The environment
 
 For that implementation to work, you have to setup a environment with kubernetes and switch the Kube-dns to CoreDns - Here you will find out how: https://kubernetes.io/docs/tasks/administer-cluster/coredns/
 
 The reason I switched kube-dns to Coredns was that it would make things easier and I wouldn't need to setup a service discovery. I will discuss the details on my coredns setup below.
 
-# Prerequisites:
+### Prerequisites:
 
 
 * Kubernetes 1.11+
@@ -57,7 +57,7 @@ So lets see how will all the kubernetes manifests look like in the end:
 We need three manifests for our ejabberd cluster and one for the Coredns config
 
 
-# The StatefulSet manifest
+### The StatefulSet manifest
 
 ````
 apiVersion: apps/v1
@@ -121,7 +121,7 @@ spec:
 
 ````
 
-# The Headless Service:
+### The Headless Service:
 
 The information regarding a headless service can be found [here](https://kubernetes.io/docs/concepts/services-networking/service/)
 
@@ -147,7 +147,7 @@ spec:
     app: xmpp
 
 ````
-# The external service:
+### The external service:
 
 That service will expose the port 5222 to the clients to connect our ejabberd cluster.
 
@@ -239,9 +239,10 @@ $kubectl apply -f /path/to/ejabberd-service.yaml
 3). Deploy the cluster
 $kubectl apply -f /path/to/statefulset.yaml
 
+````
+##Step 5 - Check cluster status
 
-Step 5 - Check cluster status
-
+````
 $kubectl exec -it chat-0 ejabberdctl list_cluster
 'ejabberd-k8s@chat-1'
 'ejabberd-k8s@chat-0'
@@ -252,4 +253,4 @@ $kubectl exec -it chat-0 ejabberdctl list_cluster
 'ejabberd-k8s@chat-0'
 ````
 
-# Happy coding!
+## Happy coding!

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,12 +1,13 @@
 ## Ejabberd + Kubernetes
 
-After some googling around, I scratched my head for why there isn't any documented steps to get Ejabberd working with K8s. For that reason after some sweeting, I was abled to setup those two together quite easily. Thanks to the awesome rroemhild/ejabberd docker image and all the scripts already created around that image.
+After some googling around, I scratched my head for why there isn't any documented steps to get Ejabberd working with K8s. For that reason after some searchers, I was abled to setup those two together quite easily. Thanks to the awesome rroemhild/ejabberd docker image and all the scripts already created around that image.
 
-Because Kubernetes needs the image pre-built with the scripts and modification I made. I built a different image available as ccpereira/ejabberd-k8s:0.0.1
+Because Kubernetes needs the image pre-built with the scripts and modifications, I built a different image available as ccpereira/ejabberd-k8s:0.0.1
 
 I would if approved, suggest rroemhild to later add that to the main branch.
 
 # New environment variable:
+
 ````
 EJABBERD_AUTO_JOIN_CLUSTER: true/false
 ````
@@ -41,7 +42,7 @@ The reason I switched kube-dns to Coredns was that it would make things easier a
 
 Firstly, there are different ways to deploy a service on Kubernetes. Here I'm using a Statefulset because of its predictable behavior. If you deploy an app with a Statefulset, as you scale up the ejabberd nodes, each ejabberd node will always have the following variation <ERLANG_NODE>@<PodHostName>.
 
-E.g: A cluster with 3 nodes  will be:
+- E.g: A cluster with 3 nodes  will be:
 
 
 * ERLANG_NODE: ejabberd-k8s
@@ -225,7 +226,7 @@ What this CoreDns config does? If we call  ejabberdctl join_cluster ejabberd-k8s
 
 ## Step 4 - Deploy the cluster
 
-If you have all setup. Just a few commands will be enough to have a cluster up and running:
+If you have all setup done. Just a few commands will be enough to have a cluster up and running:
 
 ````
 1). Apply the coredns config:

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,6 +1,6 @@
 # Ejabberd + Kubernetes
 
-After some googling around, I scratched my head for why there isn't any documented steps to get Ejabberd working with K8s. For that reason after some searchers, I was abled to setup those two together quite easily. Thanks to the awesome rroemhild/ejabberd docker image and all the scripts already created around that image.
+After some googling around, I scratched my head for why there isn't any documented steps to get Ejabberd working with K8s. For that reason after some searches, I was abled to setup those two together quite easily. Thanks to the awesome rroemhild/ejabberd docker image and all the scripts already created around that image.
 
 Because Kubernetes needs the image pre-built with the scripts and modifications, I built a different image available as ccpereira/ejabberd-k8s:0.0.1
 
@@ -240,7 +240,7 @@ $kubectl apply -f /path/to/ejabberd-service.yaml
 $kubectl apply -f /path/to/statefulset.yaml
 
 ````
-##Step 5 - Check cluster status
+## Step 5 - Check cluster status
 
 ````
 $kubectl exec -it chat-0 ejabberdctl list_cluster

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,4 +1,4 @@
-##Ejabberd + Kubernetes
+## Ejabberd + Kubernetes
 
 After some googling around, I scratched my head for why there isn't any documented steps to get Ejabberd working with K8s. For that reason after some sweeting, I was abled to setup those two together quite easily. Thanks to the awesome rroemhild/ejabberd docker image and all the scripts already created around that image.
 
@@ -6,12 +6,12 @@ Because Kubernetes needs the image pre-built with the scripts and modification I
 
 I would if approved, suggest rroemhild to later add that to the main branch.
 
-#New environment variable:
+# New environment variable:
 ````
 EJABBERD_AUTO_JOIN_CLUSTER: true/false
 ````
 
-#New script
+# New script
 
 I changed the script from the docker-compose-cluster example:
 
@@ -24,20 +24,20 @@ Some other changes:
 
 There is probably a better ways to set them together. And quite frankly, I'm not an expert on either one, but I thought, maybe someone won't waste time researching all over again, and will improve that implementation instead. So stick with me please.
 
-##Step 1 - The environment
+## Step 1 - The environment
 
 For that implementation to work, you have to setup a environment with kubernetes and switch the Kube-dns to CoreDns - Here you will find out how: https://kubernetes.io/docs/tasks/administer-cluster/coredns/
 
 The reason I switched kube-dns to Coredns was that it would make things easier and I wouldn't need to setup a service discovery. I will discuss the details on my coredns setup below.
 
-#Prerequisites:
+# Prerequisites:
 
 
 * Kubernetes 1.11+
 * CoreDns -  Install the CoreDns  - [Here is how](https://github.com/coredns/deployment/tree/master/kubernetes)
 
 
-##Step 2 - Kubernetes Manifests
+## Step 2 - Kubernetes Manifests
 
 Firstly, there are different ways to deploy a service on Kubernetes. Here I'm using a Statefulset because of its predictable behavior. If you deploy an app with a Statefulset, as you scale up the ejabberd nodes, each ejabberd node will always have the following variation <ERLANG_NODE>@<PodHostName>.
 
@@ -56,7 +56,7 @@ So lets see how will all the kubernetes manifests look like in the end:
 We need three manifests for our ejabberd cluster and one for the Coredns config
 
 
-#-The StatefulSet manifest
+# The StatefulSet manifest
 
 ````
 apiVersion: apps/v1
@@ -120,7 +120,7 @@ spec:
 
 ````
 
-#The Headless Service:
+# The Headless Service:
 
 The information regarding a headless service can be found [here](https://kubernetes.io/docs/concepts/services-networking/service/)
 
@@ -146,7 +146,7 @@ spec:
     app: xmpp
 
 ````
-#-The Client service:
+# The external service:
 
 That service will expose the port 5222 to the clients to connect our ejabberd cluster.
 
@@ -176,7 +176,7 @@ status:
 ````
 
 
-##Step 3 - CoreDNS
+## Step 3 - CoreDNS
 
 The folder coredns has the manifest coredns-deployment.yaml that will setup the coredns on our cluster.
 
@@ -223,7 +223,7 @@ data:
 What this CoreDns config does? If we call  ejabberdctl join_cluster ejabberd-k8s@pod-0 for any ejabberd node, it will redirect to the service where that host(pod) is located and we will have the node joining the ejabberd cluster.
 
 
-##Step 4 - Deploy the cluster
+## Step 4 - Deploy the cluster
 
 If you have all setup. Just a few commands will be enough to have a cluster up and running:
 
@@ -251,4 +251,4 @@ $kubectl exec -it chat-0 ejabberdctl list_cluster
 'ejabberd-k8s@chat-0'
 ````
 
-#Happy coding!
+# Happy coding!

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,0 +1,189 @@
+Ejabberd + Kubernetes
+
+
+After some googling around, I scratched my head for why there isn't any documented steps to get Ejabberd working with K8s. For that reason after some research. I was abled to setup those two together quite easily. Thanks to the awesome rroemhild/ejabberd docker image.
+
+There is probably a better and different way to set them together. And quite frankly, I'm not an expert on either one. so stick with me please.
+
+Step 1 - The environment
+
+For that implementation to work, you have to setup a environment with kubernetes and switch the Kube-dns to CoreDns [Here you will find out how]:https://kubernetes.io/docs/tasks/administer-cluster/coredns/
+
+The reason I switched kube-dns to Coredns was that it would make things easier and I wouldn't need to setup a service discovery. I will discuss the details on my coredns setup below.
+
+Prerequisites:
+
+-Kubernetes 1.11+(for that example)
+-CoreDns
+
+
+Step 2 - Kubernetes Manifests
+
+Firstly, there are different ways to deploy an service on Kubernetes. Here I'm using a Statefulset because of its predictable behavior. If you deploy an app with a Statefulset, as you scale up the ejabberd nodes, each ejabberd node will always have the following variation <ERLANG_NODE>@<PodHostName>.
+
+E.g: A cluster with 3 nodes  will be:
+
+  ERLANG_NODE: ejabberd-k8s
+
+  Pod 1: ejabberd-k8s@pod-0 (it's not a master, but lets call that the master)
+  Pod 2: ejabberd-k8s@pod-1
+  Pod 3: ejabberd-k8s@pod-2
+
+So lets see how will all the kubernetes manifests look like in the end:
+
+We need three manifests:
+
+-The StatefulSet manifest
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: chat  # Each ejabberd node will have that as it's name.
+spec:
+  selector:
+    matchLabels:
+      app: xmpp # has to match .spec.template.metadata.labels
+  serviceName: "xmpp-internal-svc" # has to match the headless-service name - the hostname will be ejabberd-{nodeNumber}.xmppservice
+  replicas: 3 # Numbers of ejabberd nodes
+  template:
+    metadata:
+      labels:
+        app: xmpp # has to match .spec.selector.matchLabels
+    spec:
+      terminationGracePeriodSeconds: 20
+      containers:
+      nodeSelector:
+        appbackend: xmpp
+      containers:
+      #Conteiner environment
+      - env:
+         # Set that to true. The nodes will join the cluster automatically.
+        - name: EJABBERD_AUTO_JOIN_CLUSTER
+          value: "true"
+        - name: EJABBERD_SKIP_MODULES_UPDATE
+          value: "true"
+        - name: EJABBERD_LOGLEVEL
+          value: "4"
+        - name: EJABBERD_S2S_SSL
+          value: "true"
+        - name: EJABBERD_STARTTLS
+          value: "true"
+        - name: EJABBERD_USER
+          value: "ejabberd"
+        - name: ERLANG_NODE
+          value: "ejabberd-k8s"
+        - name: ERLANG_COOKIE
+          value: DOYOULIKEIT
+        name: ejabberd-node
+        image: ccpereira/ejabberd-k8s:0.0.1
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 5222
+        - containerPort: 5269
+        - containerPort: 5280
+        - containerPort: 4369
+        - containerPort: 4200
+        - containerPort: 4201
+        - containerPort: 4202
+        - containerPort: 4203
+        - containerPort: 4204
+        - containerPort: 4205
+        - containerPort: 4206
+        - containerPort: 4207
+        - containerPort: 4208
+        - containerPort: 4209
+        - containerPort: 4210
+        resources: {}
+      restartPolicy: Always
+
+
+The Headless Service:
+
+The information regarding a headless service can be [found here]:https://kubernetes.io/docs/concepts/services-networking/service/
+
+The pod's name + the headless service's name will be the hostname that we need to compose our cluster:
+
+chat-0.xmpp-internal-svc
+chat-1.xmpp-internal-svc
+chat-1.xmpp-internal-svc
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: xmpp-internal-svc # That name will be part of the pods' name.
+  labels:
+    app: xmpp
+spec:
+  ports:
+  - name: c2s
+    port: 1234
+  clusterIP: None
+  selector:
+    app: xmpp
+
+
+-The Client service:
+
+That service will expose the port 5222 to the clients to connect our ejabberd cluster.
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+  labels:
+    app: xmpp
+  name: xmpp-external-svc # that service will expose the 5222 port to external connections.
+spec:
+  type: NodePort
+  selector:
+    app: xmpp
+  ports:
+  - name: c2s
+    port: 5222
+    targetPort: 5222
+    nodePort: 30395
+  - name: admin
+    port: 5280
+    targetPort: 5280
+    nodePort: 30396
+status:
+  loadBalancer: {}
+
+
+Step 3 - CoreDNS
+
+The folder coredns has the manifest coredns-deployment.yaml that will setup the coredns on our cluster.
+
+before deploy we will need to modify the CoreFile section on the ConfigMap.
+
+Pods will always have a predictable variation of it's name with Statefulset, so leveraging the coredns "rewrite" feature, we can quite easily discovery each ejabberd node. Check out the lines that starts with 'rewrite'. My implementation won't have more that 10 ejabberd nodes, that is quite enough for now. Checkout the CoreDNS rewrite [documentation]:https://github.com/coredns/coredns/tree/master/plugin/rewrite  you can user regex to improve those rules, most probably just a line will be enough.
+
+Corefile: |
+    .:53 {
+        errors
+        health
+        rewrite name chat-0.xmpp-internal-svc.default.svc.cluster.local
+        rewrite name chat-1.xmpp-internal-svc.default.svc.cluster.local
+        rewrite name chat-2.xmpp-internal-svc.default.svc.cluster.local
+        rewrite name chat-3.xmpp-internal-svc.default.svc.cluster.local
+        rewrite name chat-4.xmpp-internal-svc.default.svc.cluster.local
+        rewrite name chat-5.xmpp-internal-svc.default.svc.cluster.local
+        rewrite name chat-6.xmpp-internal-svc.default.svc.cluster.local
+        rewrite name chat-7.xmpp-internal-svc.default.svc.cluster.local
+        rewrite name chat-8.xmpp-internal-svc.default.svc.cluster.local
+        rewrite name chat-9.xmpp-internal-svc.default.svc.cluster.local
+        rewrite name chat-10.xmpp-internal-svc.default.svc.cluster.local
+        kubernetes cluster.local in-addr.arpa ip6.arpa {
+          pods insecure
+          upstream
+          fallthrough in-addr.arpa ip6.arpa
+        }
+        prometheus :9153
+        proxy . /etc/resolv.conf
+        cache 30
+        loop
+        reload
+        loadbalance
+    }
+
+What this CoreDns config does? If we call  ejabberdctl join_cluster ejabberd-k8s@pod-0 for any ejabberd node, it will redirect to the service where that host(pod) is located and we will have the node joining the ejabberd cluster.

--- a/kubernetes/coredns/coredns-configmap.yaml
+++ b/kubernetes/coredns/coredns-configmap.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns
+  namespace: kube-system
+data:
+Corefile: |
+    .:53 {
+        errors
+        health
+        rewrite name chat-0 chat-0.xmpp-internal-svc.default.svc.cluster.local
+        rewrite name chat-1 chat-1.xmpp-internal-svc.default.svc.cluster.local
+        rewrite name chat-2 chat-2.xmpp-internal-svc.default.svc.cluster.local
+        kubernetes cluster.local in-addr.arpa ip6.arpa {
+          pods insecure
+          upstream
+          fallthrough in-addr.arpa ip6.arpa
+        }
+        prometheus :9153
+        proxy . /etc/resolv.conf
+        cache 30
+        loop
+        reload
+        loadbalance
+    }

--- a/kubernetes/coredns/coredns-configmap.yaml
+++ b/kubernetes/coredns/coredns-configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: coredns
   namespace: kube-system
 data:
-Corefile: |
+  Corefile: |
     .:53 {
         errors
         health

--- a/kubernetes/ejabberd-service.yaml
+++ b/kubernetes/ejabberd-service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+  labels:
+    app: xmpp
+  name: xmpp-svc
+spec:
+  type: NodePort
+  selector:
+    app: xmpp
+  ports:
+  - name: c2s
+    port: 5222
+    targetPort: 5222
+    nodePort: 30395
+  - name: admin
+    port: 5280
+    targetPort: 5280
+    nodePort: 30396
+status:
+  loadBalancer: {}

--- a/kubernetes/ejabberd-service.yaml
+++ b/kubernetes/ejabberd-service.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
   labels:
     app: xmpp
-  name: xmpp-svc
+  name: xmpp-external-svc
 spec:
   type: NodePort
   selector:

--- a/kubernetes/headless-service.yaml
+++ b/kubernetes/headless-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: xmppservice
+  labels:
+    app: xmpp
+spec:
+  ports:
+  - name: c2s
+    port: 1234
+  clusterIP: None
+  selector:
+    app: xmpp

--- a/kubernetes/headless-service.yaml
+++ b/kubernetes/headless-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: k8service
+  name: xmpp-internal-svc
   labels:
     app: xmpp
 spec:

--- a/kubernetes/headless-service.yaml
+++ b/kubernetes/headless-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: xmppservice
+  name: k8service
   labels:
     app: xmpp
 spec:

--- a/kubernetes/run.sh
+++ b/kubernetes/run.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+set -e
+
+source "${EJABBERD_HOME}/scripts/lib/base_config.sh"
+source "${EJABBERD_HOME}/scripts/lib/config.sh"
+source "${EJABBERD_HOME}/scripts/lib/base_functions.sh"
+source "${EJABBERD_HOME}/scripts/lib/functions.sh"
+
+# discover hostname
+readonly nodename=$(get_nodename)
+
+is_zero ${ERLANG_NODE} \
+    && export ERLANG_NODE="ejabberd@localhost"
+
+## backward compatibility
+# if ERLANG_NODE is true reset it to "ejabberd" and add
+# hostname to the nodename.
+# else: export ${ERLANG_NODE} with nodename
+if (is_true ${ERLANG_NODE}); then
+    export ERLANG_NODE="ejabberd@${nodename}"
+fi
+
+
+run_scripts() {
+    local run_script_dir="${EJABBERD_HOME}/scripts/${1}"
+    for script in ${run_script_dir}/*.sh ; do
+        if [ -f ${script} -a -x ${script} ] ; then
+            echo "${script}..."
+            ${script}
+        fi
+    done
+}
+
+
+pre_scripts() {
+    run_scripts "pre"
+}
+
+
+post_scripts() {
+    run_scripts "post"
+}
+
+stop_scripts() {
+    run_scripts "stop"
+}
+
+join_cluster_scripts(){
+    run_scripts "cluster"
+}
+
+ctl() {
+    local action="$1"
+    ${EJABBERDCTL} ${action} >/dev/null
+}
+
+
+_trap() {
+    echo "Stopping ejabberd..."
+    stop_scripts
+    if ctl stop ; then
+        local cnt=0
+        sleep 1
+        while ctl status || test $? = 1 ; do
+            cnt=`expr $cnt + 1`
+            if [ $cnt -ge 60 ] ; then
+                break
+            fi
+            sleep 1
+        done
+    fi
+}
+
+
+# Catch signals and shutdown ejabberd
+trap _trap SIGTERM SIGINT
+
+## run ejabberd
+case "$@" in
+    start)
+        pre_scripts
+        tail -n 0 -F ${LOGDIR}/crash.log \
+                ${LOGDIR}/error.log \
+                ${LOGDIR}/erlang.log &
+        echo "Starting ejabberd..."
+        exec ${EJABBERDCTL} "foreground" &
+        child=$!
+        ${EJABBERDCTL} "started"
+        post_scripts
+        #await for 10 seconds before call the join cluster function.
+        #Wihtout that await the command ejabberdctl join_cluster ended unsuccessful for some reason. 
+        sleep 10
+	      join_cluster_scripts
+        wait $child
+    ;;
+    live)
+        pre_scripts
+        echo "Starting ejabberd in 'live' mode..."
+        exec ${EJABBERDCTL} "live"
+    ;;
+    shell)
+        exec "/bin/bash"
+    ;;
+    *)
+        exec $@
+    ;;
+esac

--- a/kubernetes/scripts/cluster/100_ejabberd_join_cluster.sh
+++ b/kubernetes/scripts/cluster/100_ejabberd_join_cluster.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+
+source "${EJABBERD_HOME}/scripts/lib/base_config.sh"
+source "${EJABBERD_HOME}/scripts/lib/config.sh"
+source "${EJABBERD_HOME}/scripts/lib/base_functions.sh"
+source "${EJABBERD_HOME}/scripts/lib/functions.sh"
+
+
+get_cluster_node_from_dns() {
+    local cluster_host=$(drill ${DOMAINNAME} \
+        | grep ${DOMAINNAME} \
+        | grep -v ${HOSTIP} \
+        | awk '{print $5}' \
+        | grep -v "^$" \
+        | head -1)
+    echo $(discover_dns_hostname ${cluster_host})
+}
+
+
+#file_exist ${FIRST_START_DONE_FILE} \
+#    && exit 0
+
+  if [[ $EJABBERD_AUTO_JOIN_CLUSTER == "true" ]];
+  then
+	   join_k8s_cluster $(get_cluster_node_from_dns)
+  else
+     echo "Join cluster automatically disabled  - set EJABBERD_AUTO_JOIN_CLUSTER = true"
+  fi
+exit 0

--- a/kubernetes/scripts/lib/base_functions.sh
+++ b/kubernetes/scripts/lib/base_functions.sh
@@ -1,0 +1,130 @@
+is_set() {
+    local var=$1
+
+    [[ -n $var ]]
+}
+
+
+is_zero() {
+    local var=$1
+
+    [[ -z $var ]]
+}
+
+
+file_exist() {
+    local file=$1
+
+    [[ -e $file ]]
+}
+
+
+is_true() {
+    local var=${1,,}
+    local choices=("yes" "1" "y" "true")
+    for ((i=0;i < ${#choices[@]};i++)) {
+        [[ "${choices[i]}" == $var ]] && return 0
+    }
+    return 1
+}
+
+
+# overwrite this function to get hostname from other sources
+# like dns or etcd
+get_nodename() {
+    echo ${HOSTNAME}
+}
+
+
+join_cluster() {
+    local cluster_node=$1
+
+    is_zero ${cluster_node} \
+        && exit 0
+
+    echo "Join cluster..."
+
+    local erlang_node_name=${ERLANG_NODE%@*}
+    local erlang_cluster_node="${erlang_node_name}@${cluster_node}"
+
+    response=$(${EJABBERDCTL} ping ${erlang_cluster_node})
+    while [ "$response" != "pong" ]; do
+        echo "Waiting for ${erlang_cluster_node}..."
+        sleep 2
+        response=$(${EJABBERDCTL} ping ${erlang_cluster_node})
+    done
+
+    echo "Join cluster at ${erlang_cluster_node}... "
+    NO_WARNINGS=true ${EJABBERDCTL} join_cluster $erlang_cluster_node
+
+    if [ $? -eq 0 ]; then
+        touch ${CLUSTER_NODE_FILE}
+    else
+        echo "cloud not join cluster"
+        exit 1
+    fi
+}
+
+join_k8s_cluster() {
+    local cluster_node=$1
+
+    is_zero ${cluster_node} \
+        && exit 0
+
+    echo "Host ${HOSTNAME} is gonna try to join the cluster..."
+
+    local IN=${HOSTNAME}
+
+    local domain=($(echo $IN | tr "." "\n"))
+
+    local name=($(echo ${domain[0]} | tr "-" "\n"))
+
+    local n=-1
+
+    if [ ${name[1]} == 0 ]; then
+
+      echo "Server is the Master waiting others nodes"
+      exit 0
+    fi
+
+    while [ $n -le 5 ]
+    do
+	      (( n++ ))
+      	if [ ${name[1]} == $n ]
+      	then
+      		echo "That is the current server: "${HOSTNAME}
+      		continue
+      	fi
+
+	       local nextServer=${name[0]}-$n
+
+      	echo "Trying to connect the node: $nextServer "
+
+      	local erlang_node_name=${ERLANG_NODE%@*}
+        local erlang_cluster_node="${erlang_node_name}@${nextServer}"
+
+	      response=$(${EJABBERDCTL} ping ${erlang_cluster_node})
+
+	      if [ "$response" == "pong" ]; then
+
+        		delay=$(( ${name[1]} * 10 ))
+        		echo "Joinning cluster at ${erlang_cluster_node}  with a  ${delay} sencods dalay ... "
+
+        		#delay the request for some seconds to avoid multiples nodes joinning at the same time
+        		#according with the node order
+        		#that only works ond the stateful set setup on kubernetes.
+        		sleep ${delay}
+
+        		NO_WARNINGS=true ${EJABBERDCTL} join_cluster $erlang_cluster_node
+
+        		if [ $? -eq 0 ]; then
+                		touch ${CLUSTER_NODE_FILE}
+        			      break
+            else
+                		echo "could not join the cluster"
+            fi
+      	else
+      	  sleep 4
+      	fi
+  done
+}

--- a/kubernetes/scripts/lib/functions.sh
+++ b/kubernetes/scripts/lib/functions.sh
@@ -1,0 +1,39 @@
+# Overridable file
+
+# overwrite get_nodename to discover hostname from DNS
+get_nodename() {
+    local hostname=${HOSTNAME}
+
+    # get hostname from dns
+    if ( is_true ${USE_DNS} ); then
+        # wait for dns registration
+        sleep 1
+
+        nodename=$(discover_dns_hostname ${HOSTIP})
+
+        is_set ${nodename} \
+            && hostname=${nodename}
+    fi
+
+    echo $hostname
+    return 0
+}
+
+
+# discover hostname from dns with a reverse lookup
+discover_dns_hostname() {
+    local hostip=$1
+
+    # try to get the hostname from dns
+    local dnsname=$(drill -x ${hostip} \
+        | grep PTR \
+        | awk '{print $5}' \
+        | grep -E "^[a-zA-Z0-9]+([-._]?[a-zA-Z0-9]+)*.[a-zA-Z]+\.$" \
+        | cut -d '.' -f1 \
+        | tail -1)
+
+    is_set ${dnsname} \
+        && echo ${dnsname}
+
+    return 0
+}

--- a/kubernetes/statefulset.yaml
+++ b/kubernetes/statefulset.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: ejabberd
+spec:
+  selector:
+    matchLabels:
+      app: xmpp # has to match .spec.template.metadata.labels
+  serviceName: "xmppservice" # has to match the headless-service name - the hostname will be ejabberd-{nodeNumber}.xmppservice
+  replicas: 2 # by default is 1
+  template:
+    metadata:
+      labels:
+        app: xmpp # has to match .spec.selector.matchLabels
+    spec:
+      terminationGracePeriodSeconds: 20
+      containers:
+      nodeSelector:
+        appbackend: xmpp
+      containers:
+      #Conteiner environment
+      - env:
+         #Ejabberd server settings
+        - name: EJABBERD_AUTO_JOIN_CLUSTER
+          value: "true"
+        - name: EJABBERD_SKIP_MODULES_UPDATE
+          value: "true"
+        - name: EJABBERD_LOGLEVEL
+          value: "4"
+        - name: EJABBERD_S2S_SSL
+          value: "true"
+        - name: EJABBERD_STARTTLS
+          value: "true"
+        - name: EJABBERD_USER
+          value: "ejabberd"
+        - name: ERLANG_COOKIE
+          value: DOYOULIKEIT
+        name: ejabberd-node
+        image: ccpereira/ejabberd-kubernetes
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 5222
+        - containerPort: 5269
+        - containerPort: 5280
+        - containerPort: 4369
+        - containerPort: 4200
+        - containerPort: 4201
+        - containerPort: 4202
+        - containerPort: 4203
+        - containerPort: 4204
+        - containerPort: 4205
+        - containerPort: 4206
+        - containerPort: 4207
+        - containerPort: 4208
+        - containerPort: 4209
+        - containerPort: 4210
+        resources: {}
+      restartPolicy: Always

--- a/kubernetes/statefulset.yaml
+++ b/kubernetes/statefulset.yaml
@@ -1,12 +1,12 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: ejabberd
+  name: chat
 spec:
   selector:
     matchLabels:
       app: xmpp # has to match .spec.template.metadata.labels
-  serviceName: "xmppservice" # has to match the headless-service name - the hostname will be ejabberd-{nodeNumber}.xmppservice
+  serviceName: "k8service" # has to match the headless-service name - the hostname will be ejabberd-{nodeNumber}.xmppservice
   replicas: 2 # by default is 1
   template:
     metadata:
@@ -36,7 +36,7 @@ spec:
         - name: ERLANG_COOKIE
           value: DOYOULIKEIT
         name: ejabberd-node
-        image: ccpereira/ejabberd-kubernetes
+        image: ccpereira/ejabberd-k8s:latest
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 5222

--- a/kubernetes/statefulset.yaml
+++ b/kubernetes/statefulset.yaml
@@ -1,13 +1,13 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: chat
+  name: chat # the host will be base on that name chat-0, chat-1, chat-2 as you scaleup the cluster.
 spec:
   selector:
     matchLabels:
       app: xmpp # has to match .spec.template.metadata.labels
   serviceName: "xmpp-internal-svc" # has to match the headless-service name - the hostname will be ejabberd-{nodeNumber}.xmppservice
-  replicas: 2 # by default is 1
+  replicas: 3 # The number of nodes to create
   template:
     metadata:
       labels:
@@ -18,6 +18,7 @@ spec:
       #Conteiner environment
       - env:
          #Ejabberd server settings
+         #That variable will allow the nodes to join the cluster automatically
         - name: EJABBERD_AUTO_JOIN_CLUSTER
           value: "true"
         - name: EJABBERD_SKIP_MODULES_UPDATE

--- a/kubernetes/statefulset.yaml
+++ b/kubernetes/statefulset.yaml
@@ -15,9 +15,6 @@ spec:
     spec:
       terminationGracePeriodSeconds: 20
       containers:
-      nodeSelector:
-        appbackend: xmpp
-      containers:
       #Conteiner environment
       - env:
          #Ejabberd server settings

--- a/kubernetes/statefulset.yaml
+++ b/kubernetes/statefulset.yaml
@@ -6,7 +6,7 @@ spec:
   selector:
     matchLabels:
       app: xmpp # has to match .spec.template.metadata.labels
-  serviceName: "k8service" # has to match the headless-service name - the hostname will be ejabberd-{nodeNumber}.xmppservice
+  serviceName: "xmpp-internal-svc" # has to match the headless-service name - the hostname will be ejabberd-{nodeNumber}.xmppservice
   replicas: 3 # by default is 1
   template:
     metadata:

--- a/kubernetes/statefulset.yaml
+++ b/kubernetes/statefulset.yaml
@@ -7,7 +7,7 @@ spec:
     matchLabels:
       app: xmpp # has to match .spec.template.metadata.labels
   serviceName: "xmpp-internal-svc" # has to match the headless-service name - the hostname will be ejabberd-{nodeNumber}.xmppservice
-  replicas: 3 # by default is 1
+  replicas: 2 # by default is 1
   template:
     metadata:
       labels:
@@ -34,7 +34,7 @@ spec:
         - name: EJABBERD_USER
           value: "ejabberd"
         - name: ERLANG_NODE
-          value: "ejabberdcluster"
+          value: "ejabberd-k8s"
         - name: ERLANG_COOKIE
           value: DOYOULIKEIT
         name: ejabberd-node

--- a/kubernetes/statefulset.yaml
+++ b/kubernetes/statefulset.yaml
@@ -7,7 +7,7 @@ spec:
     matchLabels:
       app: xmpp # has to match .spec.template.metadata.labels
   serviceName: "k8service" # has to match the headless-service name - the hostname will be ejabberd-{nodeNumber}.xmppservice
-  replicas: 2 # by default is 1
+  replicas: 3 # by default is 1
   template:
     metadata:
       labels:
@@ -33,10 +33,12 @@ spec:
           value: "true"
         - name: EJABBERD_USER
           value: "ejabberd"
+        - name: ERLANG_NODE
+          value: "ejabberdcluster"
         - name: ERLANG_COOKIE
           value: DOYOULIKEIT
         name: ejabberd-node
-        image: ccpereira/ejabberd-k8s:latest
+        image: ccpereira/ejabberd-k8s:0.0.1
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 5222


### PR DESCRIPTION
Hi @rroemhild,

The working example I promised I only could finish today. There is a README.md with all I could put together. 

I created a folder 'kubernetes' with all needed to deploy the working example. I was unable to build the image from the main Dockerfile duo to an error that I couldn't figure why. so I created another image based on the main  rroemhild/docker-ejabberd and uploaded as ccpereira/ejabberd-k8s:0.0.1.

As request, a new Enviroment variable criated:  EJABBERD_AUTO_JOIN_CLUSTER:true/false. if set to false, the image will behave as the original one.

I changed the script from the docker-compose-cluster example to an new one
- 100_ejabberd_join_cluster.sh

Some other small changes to:
- base_functions.sh
- functions.sh
- run.sh

The cluster is able to work on the k8s cluster, and join the nodes automatically.  It works in the following way:

Any node that is not the first of the deployment, will search for other nodes to join the cluster.  

I hope that will be useful, ping me if anything is not right, or in case of doubt.

regards, 