### PR TITLE
@all@ and @online@ in shared roster groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,14 @@ To add users to shared roster groups, separate with whitespace:
 EJABBERD_GROUP_MEMBERS=admin@example.ninja:group1@example.ninja user1@test.com:group2@test.com
 ```
 
+To add all registered users on a virtual host to a shared roster group:
+
+```
+EJABBERD_GROUP_MEMBERS=@all@@example.ninja:group1@example.ninja
+```
+
+Please take a note of the format: `@all@@example.ninja`. You need to specify not only the special directive `@all@` but also a virtual host separated by `@`.
+
 ## SSL
 - **EJABBERD_SKIP_MAKE_SSLCERT**: Skip generating ssl certificates. Default: false
 - **EJABBERD_SSLCERT_HOST**: SSL Certificate for the hostname.

--- a/conf/ejabberd.yml.tpl
+++ b/conf/ejabberd.yml.tpl
@@ -313,7 +313,7 @@ language: "en"
 
 modules:
   mod_adhoc: {}
-  {%- if env['EJABBERD_MOD_ADMIN_EXTRA'] == "true" %}
+  {% if env.get('EJABBERD_MOD_ADMIN_EXTRA', true) == "true" %}
   mod_admin_extra: {}
   {% endif %}
   mod_announce: # recommends mod_adhoc

--- a/scripts/post/30_ejabberd_setup_groups.sh
+++ b/scripts/post/30_ejabberd_setup_groups.sh
@@ -19,8 +19,8 @@ create_group() {
 register_group_member() {
     local user=$1
     local host=$2
-    local group=$1
-    local grouphost=$2
+    local group=$3
+    local grouphost=$4
 
     echo "Adding ${user} ${host} to roster group ${group}@${grouphost}"
     # Do not exit if user is already a member
@@ -53,13 +53,13 @@ register_all_group_members() {
 
     for member in ${EJABBERD_GROUP_MEMBERS} ; do
         local user=${member%%:*}
-        local group=${user#*:}
+        local group=${member#*:}
 
-        local username=${user%%@*}
-        local userhost=${user#*@}
+        local username=${user%@*}
+        local userhost=${user##*@}
 
-        local groupname=${group%%@*}
-        local grouphost=${group#*@}
+        local groupname=${group%@*}
+        local grouphost=${group##*@}
 
         register_group_member ${username} ${userhost} ${groupname} ${grouphost}
     done


### PR DESCRIPTION
Add the ability to dynamically populate the shared roster with `@all@` and `@online@` directives.
Fixes #178