### PR TITLE
fixed missing default value quotes for env.get calls in ejabberd.yml.tpl

### DIFF
--- a/conf/ejabberd.yml.tpl
+++ b/conf/ejabberd.yml.tpl
@@ -312,7 +312,7 @@ language: "en"
 
 modules:
   mod_adhoc: {}
-  {% if env.get('EJABBERD_MOD_ADMIN_EXTRA', true) == "true" %}
+  {% if env.get('EJABBERD_MOD_ADMIN_EXTRA', "true") == "true" %}
   mod_admin_extra: {}
   {% endif %}
   mod_announce: # recommends mod_adhoc
@@ -426,7 +426,7 @@ modules:
     resend_on_timeout: if_offline
   mod_time: {}
   mod_vcard: {}
-  {% if env.get('EJABBERD_MOD_VERSION', true) == "true" %}
+  {% if env.get('EJABBERD_MOD_VERSION', "true") == "true" %}
   mod_version: {}
   {% endif %}
 


### PR DESCRIPTION
The lookup calls for the environment variables for
`EJABBERD_MOD_ADMIN_EXTRA` and `EJABBERD_MOD_VERSION` are missing quotes
for the default value. They evaluate to false, while they look like
they would evaluate to true, e.g.:

```
  {% if env.get('EJABBERD_MOD_ADMIN_EXTRA', true) == "true" %}
```

This PR adds quotes (`true` => `'true'`), so that the result of the if for the missing environment variables is truthy.

If they should stay `false` by default, I would advise to change the default value from `true` to `false` instead to avoid ambiguity.

Oh, and by the way: Thank you for docker-ejabberd!