### PR TITLE
Fix open relay issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,9 @@ Please take a note of the format: `@all@@example.ninja`. You need to specify not
 
 - **EJABBERD_SKIP_MODULES_UPDATE**: If you do not need to update ejabberd modules specs, skip the update task and speedup start. Defaults to `false`.
 - **EJABBERD_MOD_MUC_ADMIN**: Activate the mod_muc_admin module. Defaults to `false`.
+- **EJABBERD_MUC_CREATE_ADMIN_ONLY**: Only allow admins to create rooms. Defaults to `false`.
 - **EJABBERD_MOD_ADMIN_EXTRA**: Activate the mod_admin_extra module. Defaults to `true`.
+- **EJABBERD_REGISTER_ADMIN_ONLY**: Only allow admins to register users. Defaults to `false`.
 - **EJABBERD_REGISTER_TRUSTED_NETWORK_ONLY**: Only allow user registration from the trusted_network access rule. Defaults to `true`.
 - **EJABBERD_MOD_VERSION**: Activate the mod_version module. Defaults to `true`.
 - **EJABBERD_SOURCE_MODULES**: List of modules, which will be installed from sources localized in ${EJABBERD_HOME}/module_source.

--- a/conf/ejabberd.yml.tpl
+++ b/conf/ejabberd.yml.tpl
@@ -412,7 +412,7 @@ modules:
     ##
     ## Only clients in the server machine can register accounts
     ##
-    {%- if env['EJABBERD_REGISTER_TRUSTED_NETWORK_ONLY'] == "true" %}
+    {%- if env.get('EJABBERD_REGISTER_TRUSTED_NETWORK_ONLY', "true") == "true" %}
     ip_access: trusted_network
     {% endif %}
 


### PR DESCRIPTION
* Sets `EJABBERD_REGISTER_TRUSTED_NETWORK_ONLY` to `true` by default, as it is claimed in the documentation.
* Documents `EJABBERD_MUC_CREATE_ADMIN_ONLY` and `EJABBERD_REGISTER_ADMIN_ONLY` as further options to secure the server.

This pull request addresses issue #192. I explicitly do not claim that this PR fixes the open relay issue, or hardens the server against attacks. Please review this PR.

@rroemhild: I would prefer to set `EJABBERD_REGISTER_ADMIN_ONLY` to `true` by default, so the default configuration is most restrictive. However this would break downward compatibility. What do you think?