### PR TITLE
Feature: permissive HTTP CORS by default

### DIFF
--- a/conf/ejabberd.yml.tpl
+++ b/conf/ejabberd.yml.tpl
@@ -337,6 +337,10 @@ modules:
     {%- else %}
     put_url: "http://@HOST@:5443"
     {% endif %}
+    custom_headers:
+        "Access-Control-Allow-Origin": "*"
+        "Access-Control-Allow-Methods": "GET, POST, PUT, OPTIONS, DELETE"
+        "Access-Control-Allow-Headers": "Content-Type, Origin, X-Requested-With"
   mod_http_upload_quota:
     max_days: {{ env.get('EJABBERD_UPLOAD_QUOTA_MAX_DAYS', 10) }}
   mod_last: {}


### PR DESCRIPTION
When using HTTP web file uploads an error occurs. It is due to the CORS settings problem as described here https://www.ejabberd.im/forum/25600/httpupload-cors-problem-external-web-app/index.html

I added the proposed headers and tested on my server: the upload works with the modifications